### PR TITLE
ProCon 2 Enabler Tool: Dev Mode fix

### DIFF
--- a/procon2tool/index.html
+++ b/procon2tool/index.html
@@ -475,8 +475,8 @@
         log('Requesting HID device...');
         const devices = await navigator.hid.requestDevice({
           filters: [
-            { vendorId: VENDOR_ID, productId: PRODUCT_ID_JOYCON_R },
-            { vendorId: VENDOR_ID, productId: PRODUCT_ID_JOYCON_L },
+            { vendorId: VENDOR_ID, productId: PRODUCT_ID_JOYCON2_R },
+            { vendorId: VENDOR_ID, productId: PRODUCT_ID_JOYCON2_L },
             { vendorId: VENDOR_ID, productId: PRODUCT_ID_PROCON2 },
             { vendorId: VENDOR_ID, productId: PRODUCT_ID_GCNSO }
           ]


### PR DESCRIPTION
Fix for the Dev Mode button in the ProCon 2 Enabler Tool, based on the fix for the Enable HID Output button. See issue #12, and see PR #11 (which this PR fixes).