### PR TITLE
Clearer Connection Hint

### DIFF
--- a/hoja2/index.html
+++ b/hoja2/index.html
@@ -24,7 +24,7 @@
                     ></tristate-button>
 
                     <span class="connect-hint">
-                        Hold A while connecting!
+                        Hold A then plug in USB!
                     </span>
             
                     <single-shot-button id="save-button" state="disabled" ready-text="Save" disabled-text="Save"


### PR DESCRIPTION
Small change to the connect-hint span on Hoja.
A Discord user mentioned that they didn't understand to plug in the USB while holding the A button on their device. They instead tried holding A while clicking on the Connect button on the web page. This commit tries to help remove that ambiguity.